### PR TITLE
Continuous drag actions and single click delay

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -124,6 +124,10 @@
     <entry name="showTooltip" type="Bool">
       <default>true</default>
     </entry>
+    
+    <entry name="isContinuous" type="Bool">
+      <default>false</default>
+    </entry>
 
     <!-- appearance -->
     <entry name="showHoverBg" type="Bool">

--- a/package/contents/ui/configActions.qml
+++ b/package/contents/ui/configActions.qml
@@ -228,10 +228,10 @@ KCM.SimpleKCM {
                     onCheckedChanged: {
                         cfg_isContinuous = checked
                     }
-                    text: i18n("Enable continuous drag events.")
+                    text: i18n("Enable continuous drag events")
                 }
                 KCM.ContextualHelpButton {
-                    toolTipText: "When continuous, drag actions occur whenever a dragging pointer moves a certain distance without needing to release the drag."
+                    toolTipText: "Keep dragging to chain actions without releasing the mouse/finger"
                 }
             }
         }

--- a/package/contents/ui/configActions.qml
+++ b/package/contents/ui/configActions.qml
@@ -52,6 +52,7 @@ KCM.SimpleKCM {
 
     property alias cfg_showTooltip: showTooltip.checked
     property alias cfg_scrollSensitivity: scrollSensitivity.value
+    property alias cfg_isContinuous: isContinuous.checked
 
     property bool isLoading: true
 
@@ -215,6 +216,22 @@ KCM.SimpleKCM {
                 }
                 KCM.ContextualHelpButton {
                     toolTipText: "Higher values may help reducing repeated scrolling events on some devices"
+                }
+            }
+            
+            RowLayout {
+                Kirigami.FormData.label: i18n("Continuous:")
+                
+                CheckBox {
+                    id: isContinuous
+                    checked: cfg_isContinuous
+                    onCheckedChanged: {
+                        cfg_isContinuous = checked
+                    }
+                    text: i18n("Enable continuous drag events.")
+                }
+                KCM.ContextualHelpButton {
+                    toolTipText: "When continuous, drag actions occur whenever a dragging pointer moves a certain distance without needing to release the drag."
                 }
             }
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -89,6 +89,36 @@ PlasmoidItem {
         "kwin,Window to"
     ]
 
+    property var blockContinuousDrag: [
+        "kwin,ExposeClass",
+        "kwin,Kill Window",
+        "kwin,Setup Window Shortcut",
+        "kwin,Toggle Window Raise/Lower",
+        "kwin,Window Above Other Windows",
+        "kwin,Window Below Other Windows",
+        "kwin,Window Fullscreen",
+        "kwin,Window Maximize",
+        "kwin,Window Move",
+        "kwin,Window Operations Menu",
+        "kwin,Window Resize",
+        "kwin,Window Shade",
+        "kwin,Window Shrink",
+        "kwin,Cube",
+        "kwin,Overview",
+        "kwin,Cycle Overview",
+        "kwin,Cycle Overview Opposite",
+        "kwin,Edit Tiles",
+        "kwin,Expose",
+        "kwin,ExposeAll",
+        "kwin,Grid View",
+    ]
+
+    function stopContinuousDrag(action) {
+        var component = action[0]
+        var actionNme = action[1]
+        return blockContinuousDrag.includes(component + "," + actionNme)
+    }
+
     property var singleClickAction: plasmoid.configuration.singleClickAction.split(",")
     property var singleClickCommand: plasmoid.configuration.singleClickCommand
     property var singleClickAppUrl: plasmoid.configuration.singleClickAppUrl
@@ -293,6 +323,10 @@ PlasmoidItem {
             }
             printLog `RUNNING_SHORTCUT: ${kwinCommand+";"+shortcutCommand}`
             executable.exec(kwinCommand+";"+shortcutCommand);
+        }
+        // end the drag for these
+        if (stopContinuousDrag(action)) {
+            dragging = false
         }
     }
 


### PR DESCRIPTION
Hi!  Love your project.  Wanted to add a couple options to make things slightly better for my use cases.  This PR adds 3 new options.

1)  Continuous
2)  Touch Friendly
3)  Enable Double Click

I'll explain briefly what each one does below.

==== 1) Continuous ====

In the traditional behavior of the panel spacer, drag actions are discrete and completed only when the drag is finished.  I wanted a continuous action that triggers whenever the pointer is moved while dragging.  This new setting allows for this behavior.

When using continuous drag actions, it's very sensitive to small motions, so for now I forcefully allowed only the axis of motion that is parallel to the panel.  When you toggle the new Continuous option, the Left/Right drag actions are disabled for vertical panels and the Up/Down drag actions are disabled for horizontal panels.  The corresponding disabled config UI elements are hidden as well.

==== 2) Touch Friendly ====

On a touch screen, I do not have middle click or mouse wheel, so this option simply disables those actions and removes them from the config UI.

==== 3) Enable Double Click ====

There is traditionally a 300ms timer on single clicks while waiting for a potential double click.  I found this to feel very sluggish in cases when I wanted to repeatedly single click.  Disabling the Double Click checkbox reduces the double click watch timer to a very small value and disables the relevant config UI.

====

When Continuous is set to False, Enable Double Click is set to True, and Touch Friendly is set to False, the behavior of the spacer with the proposed changes is identical to the traditional behavior without the PR.

Thanks again for the great widget!  Lemme know if you like any of these changes.