### PR TITLE
fix: update last active window on count change

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -211,9 +211,9 @@ PlasmoidItem {
         // onDataChanged: {
         //     updateWindowsinfo()
         // }
-        // onCountChanged: {
-        //     updateWindowsinfo()
-        // }
+        onCountChanged: {
+            updateWindowsinfo()
+        }
     }
 
     function updateWindowsinfo() {


### PR DESCRIPTION
Some newly opened windows don't seem to be registered by TaskManager's onActiveChanged But they seem to be correctly detected by onCountChanged when we update the last active one

closes: #41