### PR TITLE
fix: Use Qt.callLater as an attempt to prevent a plasma crash

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -206,13 +206,10 @@ PlasmoidItem {
         filterMinimized: true
 
         onActiveTaskChanged: {
-            updateWindowsinfo()
+            Qt.callLater(updateWindowsinfo)
         }
-        // onDataChanged: {
-        //     updateWindowsinfo()
-        // }
         onCountChanged: {
-            updateWindowsinfo()
+            Qt.callLater(updateWindowsinfo)
         }
     }
 


### PR DESCRIPTION
refs: https://github.com/luisbocanegra/plasma-panel-spacer-extended/issues/41