### PR TITLE
applets/panelspacer: Fix unchecked access, port iterator to for(of)

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -366,11 +366,12 @@ PlasmoidItem {
         let thisSpacerIndex = null;
         let sizeHints = [0];
         // Children order is guaranteed to be the same as the visual order of items in the layout
-        for (var i in panelLayout.children) {
-            const child = panelLayout.children[i];
-            if (!child.visible) continue;
+        for (const child of panelLayout.children) {
+            if (!child.visible) {
+                continue;
+            }
 
-            if (child.applet && child.applet.plasmoid.pluginName === 'luisbocanegra.panelspacer.extended' && child.applet.plasmoid.configuration.expanding) {
+            if (child.applet?.plasmoid?.pluginName === 'luisbocanegra.panelspacer.extended' && child.applet.plasmoid.configuration.expanding) {
                 if (child.applet.plasmoid === Plasmoid) {
 
                     thisSpacerIndex = expandingSpacers


### PR DESCRIPTION
Usually, child is an instance of a Loader with a `property Item applet` where applet usually an instance of PlasmaQuick::AppletQuickItem (or rather its subclass PlasmoidItem to be precise). However, applet could also be an instance of a dndSpacer placeholder, which is just an Item.

Fixes the following error when dragging a piece of text over a panel:

file:///usr/local/kde/usr/share/plasma/plasmoids/org.kde.plasma.panelspacer/contents/ui/main.qml:69: TypeError: Cannot read property 'pluginName' of undefined