### PR TITLE
fix: build quicklaunchplugin and load it conditionally (#79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/
 *.plasmoid
 
 playground/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,23 @@
 cmake_minimum_required(VERSION 3.16)
 project("plasmoid-spacer-extended")
-option(BUILD_PLUGIN "Build the plugin" OFF)
+
+set(QT_MIN_VERSION "6.8.0")
+set(KF6_MIN_VERSION "6.14.0")
+set(KDE_COMPILERSETTINGS_LEVEL "5.82")
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FeatureSummary)
+
+find_package(ECM ${KF6_MIN_VERSION} REQUIRED NO_MODULE)
+
+option(BUILD_PLUGIN "Build the plugin" ON)
 option(INSTALL_PLASMOID "Install plasmoid" ON)
 option(PACKAGE_PLASMOID "Package plasmoid" OFF)
 
-# Use Extra CMake Modules (ECM) for common functionality.
-# See http://api.kde.org/ecm/manual/ecm.7.html
-# and http://api.kde.org/ecm/manual/ecm-kde-modules.7.html
-find_package(ECM REQUIRED NO_MODULE)
-
-# Needed by find_package(KF5Plasma) below.
-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # Get id and version from metadata
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/package/metadata.json METADATA)

--- a/install.sh
+++ b/install.sh
@@ -13,3 +13,8 @@ cmake --install build
 # cmake plasma_install_package does't copy executable permission
 chmod 700 "$HOME/.local/share/plasma/plasmoids/luisbocanegra.panelspacer.extended/contents/ui/tools/get_shortcuts.sh"
 chmod 700 "$HOME/.local/share/plasma/plasmoids/luisbocanegra.panelspacer.extended/contents/ui/tools/run_kwin_script.sh"
+
+# Install plugin system-wide (required for qml modules)
+cmake -B build/plugin -S . -DINSTALL_PLASMOID=OFF -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build/plugin -j$(nproc --all)
+sudo cmake --install build/plugin

--- a/package/contents/ui/QuickLaunch.qml
+++ b/package/contents/ui/QuickLaunch.qml
@@ -1,0 +1,37 @@
+import QtQuick
+
+Item {
+    id: root
+    property bool pluginFound: false
+    property var logic
+
+    signal launcherAdded(url: string)
+
+    function addLauncher() {
+        logic.addLauncher();
+    }
+
+    function launcherData(url) {
+        return logic.launcherData(url);
+    }
+
+    function openUrl(url) {
+        logic.openUrl(url);
+    }
+
+    Component.onCompleted: {
+        let modules = ["luisbocanegra.panelspacer.extended.quicklaunch", "org.kde.plasma.private.quicklaunch"];
+
+        for (let module of modules) {
+            console.log("Trying to load", module);
+            try {
+                logic = Qt.createQmlObject(`import ${module}; Logic {}`, root);
+                pluginFound = true;
+                logic.launcherAdded.connect(root.launcherAdded);
+                break;
+            } catch (e) {
+                console.warn("Couldn't to load", module);
+            }
+        }
+    }
+}

--- a/package/contents/ui/Tooltip.qml
+++ b/package/contents/ui/Tooltip.qml
@@ -110,9 +110,11 @@ Item {
                 }
                 break;
             case "launch_application":
-                var appName = logic.launcherData(plasmoid.configuration[configKey + "AppUrl"]).applicationName;
-                if (appName.length > 0) {
-                    action = "Open • " + appName;
+                if (quickLaunch.pluginFound) {
+                    var appName = quickLaunch.launcherData(plasmoid.configuration[configKey + "AppUrl"]).applicationName;
+                    if (appName.length > 0) {
+                        action = "Open • " + appName;
+                    }
                 }
                 break;
             default:

--- a/package/contents/ui/configActions.qml
+++ b/package/contents/ui/configActions.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import org.kde.kcmutils as KCM
 import org.kde.kirigami as Kirigami
-import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasma5support as P5Support
 import "components" as Components
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -10,13 +10,12 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasmoid
 import org.kde.kirigami as Kirigami
 import org.kde.taskmanager as TaskManager
-import org.kde.plasma.private.quicklaunch
 import org.kde.plasma.plasma5support as P5Support
 import org.kde.plasma.components as PC3
 
 PlasmoidItem {
     id: root
-
+    property var logic: null
     property bool horizontal: Plasmoid.formFactor !== PlasmaCore.Types.Vertical
     property bool isWayland: Qt.platform.pluginName.includes("wayland")
     property var activeTask: null
@@ -228,10 +227,6 @@ PlasmoidItem {
         }
     }
 
-    Logic {
-        id: logic
-    }
-
     P5Support.DataSource {
         id: sendNotification
         engine: "executable"
@@ -287,7 +282,7 @@ PlasmoidItem {
                 if (application !== "") {
                     printLog`LAUNCHING_APPLICATION_URL: ${application}`;
                     notify(gestureDisplayName, `Opening ${application}`);
-                    logic.openUrl(application);
+                    quickLaunch.openUrl(application);
                 }
                 return;
             }
@@ -656,6 +651,10 @@ PlasmoidItem {
                 runAction(mouseWheelDownAction, mouseWheelDownCommand, mouseWheelDownAppUrl);
             }
         }
+    }
+
+    QuickLaunch {
+        id: quickLaunch
     }
 
     Component.onCompleted: {

--- a/plugin/.clang-format
+++ b/plugin/.clang-format
@@ -1,0 +1,95 @@
+---
+# SPDX-FileCopyrightText: 2019 Christoph Cullmann <cullmann@kde.org>
+# SPDX-FileCopyrightText: 2019 Gernot Gebhard <gebhard@absint.com>
+#
+# SPDX-License-Identifier: MIT
+
+# This file got automatically created by ECM, do not edit
+# See https://clang.llvm.org/docs/ClangFormatStyleOptions.html for the config options
+# and https://community.kde.org/Policies/Frameworks_Coding_Style#Clang-format_automatic_code_formatting
+# for clang-format tips & tricks
+---
+Language: JavaScript
+DisableFormat: true
+---
+Language: Json
+DisableFormat: false
+IndentWidth: 4
+---
+
+# Style for C++
+Language: Cpp
+
+# base is WebKit coding style: https://webkit.org/code-style-guidelines/
+# below are only things set that diverge from this style!
+BasedOnStyle: WebKit
+
+# enforce C++11 (e.g. for std::vector<std::vector<lala>>
+Standard: Cpp11
+
+# 4 spaces indent
+TabWidth: 4
+
+# 2 * 80 wide lines
+ColumnLimit: 160
+
+# sort includes inside line separated groups
+SortIncludes: true
+
+# break before braces on function, namespace and class definitions.
+BreakBeforeBraces: Linux
+
+# CrlInstruction *a;
+PointerAlignment: Right
+
+# horizontally aligns arguments after an open bracket.
+AlignAfterOpenBracket: Align
+
+# don't move all parameters to new line
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# no single line functions
+AllowShortFunctionsOnASingleLine: None
+
+# no single line enums
+AllowShortEnumsOnASingleLine: false
+
+# always break before you encounter multi line strings
+AlwaysBreakBeforeMultilineStrings: true
+
+# don't move arguments to own lines if they are not all on the same
+BinPackArguments: false
+
+# don't move parameters to own lines if they are not all on the same
+BinPackParameters: false
+
+# In case we have an if statement with multiple lines the operator should be at the beginning of the line
+# but we do not want to break assignments
+BreakBeforeBinaryOperators: NonAssignment
+
+# format C++11 braced lists like function calls
+Cpp11BracedListStyle: true
+
+# do not put a space before C++11 braced lists
+SpaceBeforeCpp11BracedList: false
+
+# remove empty lines
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# no namespace indentation to keep indent level low
+NamespaceIndentation: None
+
+# we use template< without space.
+SpaceAfterTemplateKeyword: false
+
+# Always break after template declaration
+AlwaysBreakTemplateDeclarations: true
+
+# macros for which the opening brace stays attached.
+ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH, forever, Q_FOREVER, QBENCHMARK, QBENCHMARK_ONCE , wl_resource_for_each, wl_resource_for_each_safe ]
+
+# keep lambda formatting multi-line if not empty
+AllowShortLambdasOnASingleLine: Empty
+
+# We do not want clang-format to put all arguments on a new line
+AllowAllArgumentsOnNextLine: false

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,30 +1,28 @@
-cmake_minimum_required(VERSION 3.16)
-project(plasmoid-spacer-extended-plugin)
-
-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_MODULE_PATH})
-
-set(KF5_MIN_VERSION "5.102.0")
-set(KDE_COMPILERSETTINGS_LEVEL "5.82")
-
-# Use Extra CMake Modules (ECM) for common functionality.
-# See http://api.kde.org/ecm/manual/ecm.7.html
-# and http://api.kde.org/ecm/manual/ecm-kde-modules.7.html
-
-find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
-# Needed by find_package(KF5Plasma) below.
-find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS I18n PlasmaQuick)
-
-# Locate plasma_install_package macro.
-find_package(KF5Plasma REQUIRED)
-
 include(KDEInstallDirs)
 include(KDECMakeSettings)
-include(KDECompilerSettings NO_POLICY_SCOPE)
+include(ECMQmlModule)
 
-kde_enable_exceptions()
+ecm_add_qml_module(quicklaunchplugin URI luisbocanegra.panelspacer.extended.quicklaunch)
+target_sources(quicklaunchplugin PRIVATE
+    quicklaunch_p.cpp
+    quicklaunchplugin.cpp
+)
 
-add_definitions(-DTRANSLATION_DOMAIN=\"panelspacer\")
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED
+    Core
+    Qml
+)
 
-kcoreaddons_add_plugin(luisbocanegra.panelspacer.extended SOURCES panelspacer.cpp panelspacer.h INSTALL_NAMESPACE "plasma/applets")
+find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
+    KIO
+    Notifications
+)
 
-target_link_libraries(luisbocanegra.panelspacer.extended Qt::Gui Qt::Core Qt::Qml Qt::Quick KF5::Plasma KF5::PlasmaQuick KF5::I18n)
+target_link_libraries(quicklaunchplugin PRIVATE
+    Qt::Core
+    Qt::Qml
+    KF6::KIOCore
+    KF6::KIOWidgets
+    KF6::Notifications
+)
+ecm_finalize_qml_module(quicklaunchplugin)

--- a/plugin/quicklaunch_p.cpp
+++ b/plugin/quicklaunch_p.cpp
@@ -1,0 +1,216 @@
+/*
+ *  SPDX-FileCopyrightText: 2008-2009 Lukas Appelhans <l.appelhans@gmx.de>
+ *  SPDX-FileCopyrightText: 2010-2011 Ingomar Wesp <ingomar@wesp.name>
+ *  SPDX-FileCopyrightText: 2013 Bhushan Shah <bhush94@gmail.com>
+ *  SPDX-FileCopyrightText: 2015 David Rosca <nowrep@gmail.com>
+ *
+ *  SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+
+#include "quicklaunch_p.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QRandomGenerator>
+#include <QStandardPaths>
+
+#include <KConfig>
+#include <KConfigGroup>
+#include <KDesktopFile>
+#include <KFileItem>
+#include <KIO/CommandLauncherJob>
+#include <KIO/OpenUrlJob>
+#include <KNotificationJobUiDelegate>
+#include <KOpenWithDialog>
+#include <KPropertiesDialog>
+
+#include <kio/global.h>
+
+QuicklaunchPrivate::QuicklaunchPrivate(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QVariantMap QuicklaunchPrivate::launcherData(const QUrl &url)
+{
+    QString name;
+    QString icon;
+    QString genericName;
+    QVariantList jumpListActions;
+
+    if (url.scheme() == QLatin1String("quicklaunch")) {
+        // Ignore internal scheme
+    } else if (url.isLocalFile()) {
+        const KFileItem fileItem(url);
+        const QFileInfo fi(url.toLocalFile());
+
+        if (fileItem.isDesktopFile()) {
+            const KDesktopFile f(url.toLocalFile());
+            name = f.readName();
+            icon = f.readIcon();
+            genericName = f.readGenericName();
+            if (name.isEmpty()) {
+                name = QFileInfo(url.toLocalFile()).fileName();
+            }
+
+            const QStringList &actions = f.readActions();
+
+            for (const QString &actionName : actions) {
+                const KConfigGroup &actionGroup = f.actionGroup(actionName);
+
+                if (!actionGroup.isValid() || !actionGroup.exists()) {
+                    continue;
+                }
+
+                const QString &name = actionGroup.readEntry("Name");
+                const QString &exec = actionGroup.readEntry("Exec");
+                if (name.isEmpty() || exec.isEmpty()) {
+                    continue;
+                }
+
+                jumpListActions << QVariantMap{{QStringLiteral("name"), name},
+                                               {QStringLiteral("icon"), actionGroup.readEntry("Icon")},
+                                               {QStringLiteral("exec"), exec}};
+            }
+        } else {
+            QMimeDatabase db;
+            name = fi.baseName();
+            icon = db.mimeTypeForUrl(url).iconName();
+            genericName = fi.baseName();
+        }
+    } else {
+        if (url.scheme().contains(QLatin1String("http"))) {
+            name = url.host();
+        } else if (name.isEmpty()) {
+            name = url.toString();
+            if (name.endsWith(QLatin1String(":/"))) {
+                name = url.scheme();
+            }
+        }
+        icon = KIO::iconNameForUrl(url);
+    }
+
+    return QVariantMap{{QStringLiteral("applicationName"), name},
+                       {QStringLiteral("iconName"), icon},
+                       {QStringLiteral("genericName"), genericName},
+                       {QStringLiteral("jumpListActions"), jumpListActions}};
+}
+
+void QuicklaunchPrivate::openUrl(const QUrl &url)
+{
+    auto *job = new KIO::OpenUrlJob(url);
+    job->setUiDelegate(new KNotificationJobUiDelegate(KJobUiDelegate::AutoHandlingEnabled));
+    job->setRunExecutables(true);
+    job->start();
+}
+
+void QuicklaunchPrivate::openExec(const QString &exec)
+{
+    KIO::CommandLauncherJob *job = new KIO::CommandLauncherJob(exec);
+    job->setUiDelegate(new KNotificationJobUiDelegate(KJobUiDelegate::AutoHandlingEnabled));
+    job->start();
+}
+
+void QuicklaunchPrivate::addLauncher(bool isPopup)
+{
+    KOpenWithDialog *dialog = new KOpenWithDialog();
+    dialog->setModal(false);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->hideRunInTerminal();
+    dialog->setSaveNewApplications(true);
+    dialog->show();
+
+    connect(dialog, &KOpenWithDialog::accepted, this, [this, dialog, isPopup]() {
+        if (!dialog->service()) {
+            return;
+        }
+        const QUrl &url = QUrl::fromLocalFile(dialog->service()->entryPath());
+        if (url.isValid()) {
+            Q_EMIT launcherAdded(url.toString(), isPopup);
+        }
+    });
+}
+
+static QString locateLocal(const QString &file)
+{
+    const QString &dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    const QString appDataPath = QStringLiteral("%1/quicklaunch").arg(dataPath);
+    QDir().mkpath(appDataPath);
+    return QStringLiteral("%1/%2").arg(appDataPath, file);
+}
+
+static QString determineNewDesktopFilePath(const QString &baseName)
+{
+    QString appendix;
+    QString desktopFilePath = locateLocal(baseName) + QLatin1String(".desktop");
+
+    auto *generator = QRandomGenerator::global();
+    while (QFile::exists(desktopFilePath)) {
+        if (appendix.isEmpty()) {
+            appendix += QLatin1Char('-');
+        }
+
+        // Limit to [0-9] and [a-z] range.
+        char newChar = generator->bounded(36);
+        newChar += newChar < 10 ? 48 : 97 - 10;
+        appendix += QLatin1Char(newChar);
+
+        desktopFilePath = locateLocal(baseName + appendix + QLatin1String(".desktop"));
+    }
+
+    return desktopFilePath;
+}
+
+void QuicklaunchPrivate::editLauncher(QUrl url, int index, bool isPopup)
+{
+    // If the launcher does not point to a desktop file, create one,
+    // so that user can change url, icon, text and description.
+    bool desktopFileCreated = false;
+
+    if (!url.isLocalFile() || !KDesktopFile::isDesktopFile(url.toLocalFile())) {
+        const QString desktopFilePath = determineNewDesktopFilePath(QStringLiteral("launcher"));
+        const QVariantMap data = launcherData(url);
+
+        KConfig desktopFile(desktopFilePath);
+        KConfigGroup desktopEntry(&desktopFile, "Desktop Entry");
+
+        desktopEntry.writeEntry("Name", data.value(QStringLiteral("applicationName")).toString());
+        desktopEntry.writeEntry("Comment", data.value(QStringLiteral("genericName")).toString());
+        desktopEntry.writeEntry("Icon", data.value(QStringLiteral("iconName")).toString());
+        desktopEntry.writeEntry("Type", "Link");
+        desktopEntry.writeEntry("URL", url);
+
+        desktopEntry.sync();
+
+        url = QUrl::fromLocalFile(desktopFilePath);
+        desktopFileCreated = true;
+    }
+
+    KPropertiesDialog *dialog = new KPropertiesDialog(url);
+    dialog->setModal(false);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
+
+    connect(dialog, &KPropertiesDialog::accepted, this, [this, dialog, index, isPopup]() {
+        QUrl url = dialog->url();
+        QString path = url.toLocalFile();
+
+        // If the user has renamed the file, make sure that the new
+        // file name has the extension ".desktop".
+        if (!path.endsWith(QLatin1String(".desktop"))) {
+            QFile::rename(path, path + QLatin1String(".desktop"));
+            path += QLatin1String(".desktop");
+            url = QUrl::fromLocalFile(path);
+        }
+        Q_EMIT launcherEdited(url.toString(), index, isPopup);
+    });
+
+    connect(dialog, &KPropertiesDialog::rejected, this, [url, desktopFileCreated]() {
+        if (desktopFileCreated) {
+            // User didn't save the data, delete the temporary desktop file.
+            QFile::remove(url.toLocalFile());
+        }
+    });
+}

--- a/plugin/quicklaunch_p.h
+++ b/plugin/quicklaunch_p.h
@@ -1,0 +1,33 @@
+/*
+ *  SPDX-FileCopyrightText: 2015 David Rosca <nowrep@gmail.com>
+ *
+ *  SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+
+#ifndef QUICKLAUNCH_P_H
+#define QUICKLAUNCH_P_H
+
+#include <QObject>
+#include <QUrl>
+#include <QVariantMap>
+
+class QuicklaunchPrivate : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit QuicklaunchPrivate(QObject *parent = nullptr);
+
+    Q_INVOKABLE QVariantMap launcherData(const QUrl &url);
+    Q_INVOKABLE void openUrl(const QUrl &url);
+    Q_INVOKABLE void openExec(const QString &exec);
+
+    Q_INVOKABLE void addLauncher(bool isPopup = false);
+    Q_INVOKABLE void editLauncher(QUrl url, int index, bool isPopup = false);
+
+Q_SIGNALS:
+    void launcherAdded(const QString &url, bool isPopup);
+    void launcherEdited(const QString &url, int index, bool isPopup);
+};
+
+#endif // QUICKLAUNCH_P_H

--- a/plugin/quicklaunchplugin.cpp
+++ b/plugin/quicklaunchplugin.cpp
@@ -1,0 +1,24 @@
+/*
+ *  SPDX-FileCopyrightText: 2015 David Rosca <nowrep@gmail.com>
+ *
+ *  SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+
+#include "quicklaunch_p.h"
+
+#include <QQmlEngine>
+#include <QQmlExtensionPlugin>
+
+class QuicklaunchPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QQmlExtensionInterface")
+
+public:
+    void registerTypes(const char *uri) override
+    {
+        qmlRegisterType<QuicklaunchPrivate>(uri, 1, 0, "Logic");
+    }
+};
+
+#include "quicklaunchplugin.moc"


### PR DESCRIPTION
Due to changes in kdeplasma-addons/applets/quicklaunch the plugin can no longer be imported by other widgets, so now we build and ship it under a different namespace.

Permalink: https://invent.kde.org/plasma/kdeplasma-addons/-/tree/Plasma/6.4/applets/quicklaunch/plugin?ref_type=heads

The plugin is now loaded conditionally, if it's not found, Launch application/url feature is disabled